### PR TITLE
Exclude project tags from task tag list

### DIFF
--- a/src/configLoader.ts
+++ b/src/configLoader.ts
@@ -181,7 +181,9 @@ export class ConfigLoader {
                     if (line.tags && line.tags.length > 0) {
                         const tag = line.tags[0];
                         this.plugin.settings.projectTags.push(tag);
-                        foundTags.push(tag);
+                        // Project tags should not be treated as task tags,
+                        // so avoid adding them to the list of found task tags.
+                        // foundTags.push(tag);
                     }
                 }
 
@@ -276,8 +278,10 @@ export class ConfigLoader {
                     }
                 }
 
-                // Update plugin settings taskTags
-                this.plugin.settings.taskTags = [...new Set(foundTags)]; // Deduplicate
+                // Update plugin settings taskTags without including project tags
+                this.plugin.settings.taskTags = [...new Set(foundTags)].filter(
+                    tag => !this.plugin.settings.projectTags.includes(tag)
+                );
                 console.log("Loaded tags from file:", this.plugin.settings.taskTags);
                 console.log("Configured connectors:", Object.keys(this.plugin.settings.webTags));
 


### PR DESCRIPTION
## Summary
- avoid adding project tags to `taskTags`
- filter project tags when deduplicating so only real task tags remain

## Testing
- `npm run build` *(fails: Parameter 'c' implicitly has an 'any' type etc.)*
- `node - <<'NODE'
const foundTags=['#task','#project'];
const projectTags=['#project'];
const taskTags=[...new Set(foundTags)].filter(tag=>!projectTags.includes(tag));
console.log(taskTags);
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68b508a574f8833293a6d4ae66ba8ec4