### PR TITLE
Prevent fuzzy finder retrigger after cancel

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -356,14 +356,15 @@ export default class ObsidianPlus extends Plugin {
 			})
 		);
 
-		this.registerEvent(
-		this.app.workspace.on('editor-change', (editor: Editor, info: any) => {
-			if (info instanceof MarkdownView) {
-				this.handleBulletPreference(editor); // Keep this line
-				this.autoConvertTagToTask(editor);
-			}
-		})
-		);
+                this.registerEvent(
+                this.app.workspace.on('editor-change', (editor: Editor, info: any) => {
+                        this._suggester?.resetPromptGuard();
+                        if (info instanceof MarkdownView) {
+                                this.handleBulletPreference(editor); // Keep this line
+                                this.autoConvertTagToTask(editor);
+                        }
+                })
+                );
 
 		function expandIfNeeded(evt: MouseEvent) {
 			const target = evt.target.closest('.op-expandable-item');


### PR DESCRIPTION
## Summary
- cache the last handled `- ?` prompt so the task tag suggester does not reopen immediately after canceling
- reset the prompt guard on document edits so freshly typed prompts still launch the fuzzy finder

## Testing
- npm run build *(fails: pre-existing TypeScript errors in the project)*

------
https://chatgpt.com/codex/tasks/task_e_68dff45bfec083329a28a859d75fb6ef